### PR TITLE
Add loading indicator to run simulation button (issue #3)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <LINK REL=StyleSheet HREF="css/monte.css" TYPE="text/css" MEDIA=screen>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
   </head>
   <body>
@@ -41,7 +42,9 @@
       <label for="simulationPasses">Number of times to run the simulation:</label>
       <input type="number" min="1000" max="9999999" step="100" id="simulationPasses" value="100000" length="10">
       <br>
-      <input type="button" value="Run Simulation" id="startSimulationButton">
+      <button class="button" id="startSimulationButton">
+        <i class="fas"></i> Run Simulation
+      </button>
       <input type="checkbox" value="1" id="limitGraph"><label for="limitGraph">Limit graph outliers</label>
       <div id="simulationResultsWrapper">
         <div id="simulationRunningTime"></div>
@@ -58,6 +61,7 @@
     <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
     <script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
     <script src="js/jquery.csv.js"></script>
+    <script src="js/jquery.buttonloadingindicator.js"></script>
 
     <!-- Requirements for d3 viz-->
     <script src="//d3js.org/d3.v3.min.js" charset="utf-8"></script>

--- a/js/jquery.buttonloadingindicator.js
+++ b/js/jquery.buttonloadingindicator.js
@@ -1,0 +1,30 @@
+/**
+ * Button loading indicator plugin
+ * MIT License
+ * Source: https://www.jqueryscript.net/loading/button-loading-indicator-font-awesome.html
+ */
+
+(function( $ ) {
+ 
+    $.fn.startLoading = function() {
+        return this.each(function() {
+            $(this).attr("disabled", true).addClass("disabled");
+
+            $icon = $(this).find('i');
+            $icon.data('loader-icons', $icon.attr('class'))
+            $icon.removeAttr('class');
+            $icon.addClass("fa").addClass("fa-spin").addClass("fa-spinner");
+        });
+    }
+ 
+    $.fn.stopLoading = function() {
+        return this.each(function() {
+            $(this).removeAttr("disabled").removeClass("disabled");
+            
+            $icon = $(this).find('i');
+            $icon.removeAttr('class');
+            $icon.attr('class', $icon.data('loader-icons'));
+        });
+    }
+ 
+}( jQuery ));

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -6,7 +6,16 @@ $(document).ready(function() {
 
   // The event listener for the file upload
   $('#csvFileInput').change(upload);
-  $('#startSimulationButton').click(runSimulation);
+  $('#startSimulationButton').click(() => {
+      $('#startSimulationButton i').addClass('fa-spinner');
+      $('#startSimulationButton').startLoading();
+      // Not the best solution but using setTimeout() to force the browser to repaint the UI
+      setTimeout(runSimulation, 100);
+      setTimeout(() => {
+        $('#startSimulationButton').stopLoading();
+        $('#startSimulationButton i').removeClass('fa-spinner');
+      }, 100);
+  });
   $('#simulationResultsWrapper').hide();
   $('#simulationAreaWrapper').hide();
   $('#addTaskBtn').click(addRowEvent);
@@ -141,7 +150,6 @@ $(document).ready(function() {
     });
 
     buildHistogram(trimmed, lower, upper, median, sd);
-
   }
 
   // Calculate the longest time the simulator may come up with.


### PR DESCRIPTION
I'd like to get some feedback on this solution. I had a little trouble getting the browser to repaint the UI when using `addClass()`/`removeClass()` and needed to set an arbitrary timeout in order to force the UI to update. I don't think this would be an issue if the simulation processing was done on a separate thread and we used promises to change the loading state (maybe an ajax call to an api server, etc). It seemed like I would call `.addClass()` and the processing would happen and lock the UI thread before the DOM could get updated.

This solution also includes the use of a jquery plugin I found for animating the loading icon on the button.

Anyways, let me know what you think! 🙂 